### PR TITLE
Fix MessageMerger to preserve insertion order for null-MessageId updates

### DIFF
--- a/dotnet/src/Microsoft.Agents.AI.Workflows/MessageMerger.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Workflows/MessageMerger.cs
@@ -4,7 +4,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Extensions.AI;
-using Microsoft.Shared.Diagnostics;
 
 namespace Microsoft.Agents.AI.Workflows;
 
@@ -14,66 +13,31 @@ internal sealed class MessageMerger
     {
         public string? ResponseId { get; } = responseId;
 
-        public Dictionary<string, List<AgentResponseUpdate>> UpdatesByMessageId { get; } = [];
-        public List<AgentResponseUpdate> DanglingUpdates { get; } = [];
+        public List<AgentResponseUpdate> OrderedUpdates { get; } = [];
 
         public void AddUpdate(AgentResponseUpdate update)
         {
-            if (update.MessageId is null)
-            {
-                this.DanglingUpdates.Add(update);
-            }
-            else
-            {
-                if (!this.UpdatesByMessageId.TryGetValue(update.MessageId, out List<AgentResponseUpdate>? updates))
-                {
-                    this.UpdatesByMessageId[update.MessageId] = updates = [];
-                }
-
-                updates.Add(update);
-            }
+            this.OrderedUpdates.Add(update);
         }
 
-        public AgentResponse ComputeMerged(string messageId)
+        public AgentResponse ComputeOrdered()
         {
-            if (this.UpdatesByMessageId.TryGetValue(Throw.IfNull(messageId), out List<AgentResponseUpdate>? updates))
+            if (this.OrderedUpdates.Count == 0)
             {
-                return updates.ToAgentResponse();
+                throw new InvalidOperationException("No updates to compute a response from.");
             }
 
-            throw new KeyNotFoundException($"No updates found for message ID '{messageId}' in response '{this.ResponseId}'.");
-        }
-
-        public AgentResponse ComputeDangling()
-        {
-            if (this.DanglingUpdates.Count == 0)
-            {
-                throw new InvalidOperationException("No dangling updates to compute a response from.");
-            }
-
-            return this.DanglingUpdates.ToAgentResponse();
+            return this.OrderedUpdates.ToAgentResponse();
         }
 
         public List<ChatMessage> ComputeFlattened()
         {
-            List<ChatMessage> result = this.UpdatesByMessageId.Keys.SelectMany(AggregateUpdatesToMessage).ToList();
-            if (this.DanglingUpdates.Count > 0)
+            if (this.OrderedUpdates.Count == 0)
             {
-                result.AddRange(this.ComputeDangling().Messages);
+                return [];
             }
 
-            return result;
-
-            IList<ChatMessage> AggregateUpdatesToMessage(string messageId)
-            {
-                List<AgentResponseUpdate> updates = this.UpdatesByMessageId[messageId];
-                if (updates.Count == 0)
-                {
-                    throw new InvalidOperationException($"No updates found for message ID '{messageId}' in response '{this.ResponseId}'.");
-                }
-
-                return updates.Select(oldUpdate => oldUpdate.AsChatResponseUpdate()).ToChatResponse().Messages;
-            }
+            return this.ComputeOrdered().Messages.ToList();
         }
     }
 
@@ -84,7 +48,7 @@ internal sealed class MessageMerger
     {
         if (update.ResponseId is null)
         {
-            this._danglingState.DanglingUpdates.Add(update);
+            this._danglingState.AddUpdate(update);
         }
         else
         {
@@ -95,28 +59,6 @@ internal sealed class MessageMerger
 
             state.AddUpdate(update);
         }
-    }
-
-    private int CompareByDateTimeOffset(AgentResponse left, AgentResponse right)
-    {
-        const int LESS = -1, EQ = 0, GREATER = 1;
-
-        if (left.CreatedAt == right.CreatedAt)
-        {
-            return EQ;
-        }
-
-        if (!left.CreatedAt.HasValue)
-        {
-            return GREATER;
-        }
-
-        if (!right.CreatedAt.HasValue)
-        {
-            return LESS;
-        }
-
-        return left.CreatedAt.Value.CompareTo(right.CreatedAt.Value);
     }
 
     public AgentResponse ComputeMerged(string primaryResponseId, string? primaryAgentId = null, string? primaryAgentName = null)
@@ -130,15 +72,9 @@ internal sealed class MessageMerger
         {
             ResponseMergeState mergeState = this._mergeStates[responseId];
 
-            List<AgentResponse> responseList = mergeState.UpdatesByMessageId.Keys.Select(mergeState.ComputeMerged).ToList();
-            if (mergeState.DanglingUpdates.Count > 0)
-            {
-                responseList.Add(mergeState.ComputeDangling());
-            }
-
-            responseList.Sort(this.CompareByDateTimeOffset);
-            responses[responseId] = responseList.Aggregate(MergeResponses);
-            messages.AddRange(GetMessagesWithCreatedAt(responses[responseId]));
+            AgentResponse orderedResponse = mergeState.ComputeOrdered();
+            responses[responseId] = orderedResponse;
+            messages.AddRange(GetMessagesWithCreatedAt(orderedResponse));
         }
 
         UsageDetails? usage = null;
@@ -193,34 +129,6 @@ internal sealed class MessageMerger
             Usage = usage,
             AdditionalProperties = additionalProperties
         };
-
-        static AgentResponse MergeResponses(AgentResponse? current, AgentResponse incoming)
-        {
-            if (current is null)
-            {
-                return incoming;
-            }
-
-            if (current.ResponseId != incoming.ResponseId)
-            {
-                throw new InvalidOperationException($"Cannot merge responses with different IDs: '{current.ResponseId}' and '{incoming.ResponseId}'.");
-            }
-
-            List<object?> rawRepresentation = current.RawRepresentation as List<object?> ?? [];
-            rawRepresentation.Add(incoming.RawRepresentation);
-
-            return new()
-            {
-                AgentId = incoming.AgentId ?? current.AgentId,
-                AdditionalProperties = MergeProperties(current.AdditionalProperties, incoming.AdditionalProperties),
-                CreatedAt = incoming.CreatedAt ?? current.CreatedAt,
-                FinishReason = incoming.FinishReason ?? current.FinishReason,
-                Messages = current.Messages.Concat(incoming.Messages).ToList(),
-                ResponseId = current.ResponseId,
-                RawRepresentation = rawRepresentation,
-                Usage = MergeUsage(current.Usage, incoming.Usage),
-            };
-        }
 
         static IEnumerable<ChatMessage> GetMessagesWithCreatedAt(AgentResponse response)
         {

--- a/dotnet/tests/Microsoft.Agents.AI.Workflows.UnitTests/MessageMergerTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Workflows.UnitTests/MessageMergerTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System;
+using System.Linq;
 using FluentAssertions;
 using Microsoft.Extensions.AI;
 
@@ -68,5 +69,75 @@ public class MessageMergerTests
 
         // Assert - FinishReason from the update should propagate through
         response.FinishReason.Should().Be(ChatFinishReason.ContentFilter);
+    }
+
+    [Fact]
+    public void Test_MessageMerger_NullMessageId_CoalescesWithAdjacentUpdates()
+    {
+        // Simulates the MEAI OpenAIResponsesChatClient behavior where reasoning
+        // content streams with MessageId = null while text gets a proper MessageId.
+        // The merger should preserve insertion order so that ToChatResponse()
+        // coalesces null-MessageId updates with the surrounding message.
+        DateTimeOffset creationTime = DateTimeOffset.UtcNow;
+        string responseId = Guid.NewGuid().ToString("N");
+        string textMessageId = Guid.NewGuid().ToString("N");
+
+        MessageMerger merger = new();
+
+        // Reasoning updates with null MessageId (the MEAI bug)
+        merger.AddUpdate(new AgentResponseUpdate
+        {
+            Role = ChatRole.Assistant,
+            AuthorName = TestAuthorName1,
+            Contents = [new TextReasoningContent("Let me think...")],
+            ResponseId = responseId,
+            AgentId = TestAgentId1,
+            CreatedAt = creationTime,
+            MessageId = null,
+        });
+
+        merger.AddUpdate(new AgentResponseUpdate
+        {
+            Contents = [new TextReasoningContent(" 2 + 2 = 4.")],
+            ResponseId = responseId,
+            AgentId = TestAgentId1,
+            CreatedAt = creationTime,
+            MessageId = null,
+        });
+
+        // Text updates with a proper MessageId
+        merger.AddUpdate(new AgentResponseUpdate
+        {
+            Role = ChatRole.Assistant,
+            AuthorName = TestAuthorName1,
+            Contents = [new TextContent("The answer is ")],
+            ResponseId = responseId,
+            AgentId = TestAgentId1,
+            CreatedAt = creationTime,
+            MessageId = textMessageId,
+        });
+
+        merger.AddUpdate(new AgentResponseUpdate
+        {
+            Contents = [new TextContent("4.")],
+            ResponseId = responseId,
+            AgentId = TestAgentId1,
+            CreatedAt = creationTime,
+            MessageId = textMessageId,
+        });
+
+        AgentResponse response = merger.ComputeMerged(responseId);
+
+        // Reasoning and text should be coalesced into the same message
+        // because null MessageId is treated as "same message" by ToChatResponse().
+        response.Messages.Should().HaveCount(1);
+        response.Messages[0].Role.Should().Be(ChatRole.Assistant);
+        response.Messages[0].AuthorName.Should().Be(TestAuthorName1);
+
+        var reasoningContents = response.Messages[0].Contents.OfType<TextReasoningContent>().ToList();
+        var textContents = response.Messages[0].Contents.OfType<TextContent>().ToList();
+
+        reasoningContents.Should().NotBeEmpty("reasoning content should be in the message");
+        textContents.Should().NotBeEmpty("text content should be in the message");
     }
 }


### PR DESCRIPTION
## Problem

When using the OpenAI Responses API with reasoning models (e.g., `o4-mini`, `gpt-5.4`), MEAI's `OpenAIResponsesChatClient` streams reasoning content updates with `MessageId = null` while text content updates get a proper `MessageId`.

`MessageMerger` (used by `WorkflowHostAgent.RunAsync()`) previously split updates into two separate buckets:
- `UpdatesByMessageId` — updates with a valid `MessageId`
- `DanglingUpdates` — updates with `MessageId = null`

These were processed separately, causing **reasoning content to be disconnected from its text output** in the final `AgentResponse`. Instead of one message containing both reasoning and text, the result was two separate messages.

## Root Cause

In `MessageMerger.ResponseMergeState.AddUpdate()`, null-`MessageId` updates were quarantined into `DanglingUpdates`. When `ComputeMerged` ran, it processed each bucket independently — `DanglingUpdates` became a separate `AgentResponse` via `ComputeDangling()`, producing a disconnected message.

## Fix

Preserve insertion order of all updates in an `OrderedUpdates` list and process them as a single ordered stream through MEAI's `ToChatResponse()`. This coalescing logic already handles null `MessageId` correctly — it treats it as "belongs to the current message" (via `NotEmptyOrEqual` returning `false` when either value is null/empty).

### Changes:
- **`MessageMerger.cs`** — Simplified `ResponseMergeState` to use a single ordered list. Removed the split-bucket approach (`DanglingUpdates`/`UpdatesByMessageId` separation in compute). Removed unused `CompareByDateTimeOffset` and `MergeResponses` methods.
- **`MessageMergerTests.cs`** — Added `Test_MessageMerger_NullMessageId_CoalescesWithAdjacentUpdates` verifying that reasoning (null MessageId) and text (valid MessageId) are coalesced into the same message.

## E2E Verification

Tested with live Azure OpenAI `gpt-5.4` deployment through the full workflow pipeline:

**Before fix:**
```
AgentResponse has 2 message(s):
  Message[0]: MessageId=msg_... | Reasoning=0, Text=1
  Message[1]: MessageId=(null) | Reasoning=1, Text=0
✗ BUG: Reasoning and text are in SEPARATE messages.
```

**After fix:**
```
AgentResponse has 1 message(s):
  Message[0]: MessageId=msg_... | Reasoning=1, Text=1
✓ Reasoning and text are in the SAME message.
```

Fixes microsoft/agent-framework#4452